### PR TITLE
DrugFlow: examples part 1

### DIFF
--- a/documentation/drugflow.ipynb
+++ b/documentation/drugflow.ipynb
@@ -148,6 +148,121 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3468f219",
+   "metadata": {},
+   "source": [
+    "## Using DrugFlow\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "295f23a1",
+   "metadata": {},
+   "source": [
+    "### Drugflow example\n",
+    "\n",
+    "First, lets start by printing out the drugflow respository `generate.py --help` script to see what options are available.\n",
+    "\n",
+    "```bash\n",
+    "usage: generate.py [-h] --protein PROTEIN --ref_ligand REF_LIGAND --checkpoint\n",
+    "                   CHECKPOINT [--molecule_size MOLECULE_SIZE]\n",
+    "                   [--output OUTPUT] [--n_samples N_SAMPLES]\n",
+    "                   [--batch_size BATCH_SIZE]\n",
+    "                   [--pocket_distance_cutoff POCKET_DISTANCE_CUTOFF]\n",
+    "                   [--n_steps N_STEPS] [--device DEVICE] [--datadir DATADIR]\n",
+    "                   [--seed SEED] [--filter] [--metrics_output METRICS_OUTPUT]\n",
+    "                   [--gnina GNINA] [--reduce REDUCE]\n",
+    "\n",
+    "options:\n",
+    "  -h, --help            show this help message and exit\n",
+    "  --protein PROTEIN     Input PDB file.\n",
+    "  --ref_ligand REF_LIGAND\n",
+    "                        SDF file with reference ligand used to define the\n",
+    "                        pocket.\n",
+    "  --checkpoint CHECKPOINT\n",
+    "                        Model checkpoint file.\n",
+    "  --molecule_size MOLECULE_SIZE\n",
+    "                        Maximum number of atoms in the sampled molecules. Can\n",
+    "                        be a single number or a range, e.g. '15,20'. If None,\n",
+    "                        size will be sampled.\n",
+    "  --output OUTPUT       Output file.\n",
+    "  --n_samples N_SAMPLES\n",
+    "                        Number of sampled molecules.\n",
+    "  --batch_size BATCH_SIZE\n",
+    "                        Batch size.\n",
+    "  --pocket_distance_cutoff POCKET_DISTANCE_CUTOFF\n",
+    "                        Distance cutoff to define the pocket around the\n",
+    "                        reference ligand.\n",
+    "  --n_steps N_STEPS     Number of denoising steps.\n",
+    "  --device DEVICE       Device to use.\n",
+    "  --datadir DATADIR     Needs to be specified to sample molecule sizes.\n",
+    "  --seed SEED           Random seed.\n",
+    "  --filter              Apply basic filters and keep sampling until\n",
+    "                        `n_samples` molecules passing these filters are found.\n",
+    "  --metrics_output METRICS_OUTPUT\n",
+    "                        If provided, metrics will be computed and saved in csv\n",
+    "                        format at this location.\n",
+    "  --gnina GNINA         Path to a gnina executable. Required for computing\n",
+    "                        docking scores.\n",
+    "  --reduce REDUCE       Path to a reduce executable. Required for computing\n",
+    "                        interactions.\n",
+    "```\n",
+    "\n",
+    "\n",
+    "Next, lets go ahead an run the example kras protein target and ligand.\n",
+    "\n",
+    "![kras-ligand](https://storage.googleapis.com/gn-portfolio/images/kras_drugflow_example.gif)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b50ff1e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python /workspace/src/generate.py \\\n",
+    "  --protein /workspace/examples/kras.pdb \\\n",
+    "  --ref_ligand /workspace/examples/kras_ref_ligand.sdf \\\n",
+    "  --checkpoint /models/drugflow/drugflow.ckpt \\\n",
+    "  --output /workspace/examples/samples.sdf \\\n",
+    "  --n_steps 20 \\\n",
+    "  --n_samples 50\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d438c11c",
+   "metadata": {},
+   "source": [
+    "Below is the example of the output generated from DrugFlow generation.\n",
+    "\n",
+    "![DrugFlow Example Output](../assets/images/drugflow/state-sweep-example.gif)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4dbffe1",
+   "metadata": {},
+   "source": [
+    "### Benchmarking\n",
+    "\n",
+    "Lets go ahead and push the limits of DrugFlow's generative capability and see how well it can be used as part of a drug discovery pipeline. The steps are as follows:\n",
+    "\n",
+    "1. Generate binding pocket of known orthosteric drugs with native proteins\n",
+    "2. Use native protein as ligand to generate small molecule binders to target using DrugFlow\n",
+    "3. Rank small molecules using Boltz2 with affinity prediction\n",
+    "4. With library of FDA approved drugs, identify most similar compound to top ranked Boltz molecules.\n",
+    "\n",
+    "#### Gnerate Binding Pocket\n",
+    "\n",
+    "Below we will be using bcl2-bax complex as the starting complex. We exported the bax ligand, as a sdf file, and kept bcl2 in pdb format to make `generate.py` function to work."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "e2b66b09",
@@ -191,124 +306,124 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b50ff1e1",
+   "cell_type": "markdown",
+   "id": "cbc1389c",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "!python /workspace/src/generate.py \\\n",
-    "  --protein /workspace/examples/kras.pdb \\\n",
-    "  --ref_ligand /workspace/examples/kras_ref_ligand.sdf \\\n",
-    "  --checkpoint /models/drugflow/drugflow.ckpt \\\n",
-    "  --output /workspace/examples/samples.sdf \\\n",
-    "  --n_steps 20 \\\n",
-    "  --n_samples 50\n"
+    "Next, lets go ahead and filter out any generated samples with multiple molecules."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "58fc5c01",
+   "execution_count": 1,
+   "id": "3f86e621",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/miniconda/envs/drugflow/lib/python3.11/site-packages/MDAnalysis/topology/tables.py:52: DeprecationWarning: Deprecated in version 2.8.0\n",
-      "MDAnalysis.topology.tables has been moved to MDAnalysis.guesser.tables. This import point will be removed in MDAnalysis version 3.0.0\n",
-      "  warnings.warn(wmsg, category=DeprecationWarning)\n",
-      "usage: generate.py [-h] --protein PROTEIN --ref_ligand REF_LIGAND --checkpoint\n",
-      "                   CHECKPOINT [--molecule_size MOLECULE_SIZE]\n",
-      "                   [--output OUTPUT] [--n_samples N_SAMPLES]\n",
-      "                   [--batch_size BATCH_SIZE]\n",
-      "                   [--pocket_distance_cutoff POCKET_DISTANCE_CUTOFF]\n",
-      "                   [--n_steps N_STEPS] [--device DEVICE] [--datadir DATADIR]\n",
-      "                   [--seed SEED] [--filter] [--metrics_output METRICS_OUTPUT]\n",
-      "                   [--gnina GNINA] [--reduce REDUCE]\n",
-      "\n",
-      "options:\n",
-      "  -h, --help            show this help message and exit\n",
-      "  --protein PROTEIN     Input PDB file.\n",
-      "  --ref_ligand REF_LIGAND\n",
-      "                        SDF file with reference ligand used to define the\n",
-      "                        pocket.\n",
-      "  --checkpoint CHECKPOINT\n",
-      "                        Model checkpoint file.\n",
-      "  --molecule_size MOLECULE_SIZE\n",
-      "                        Maximum number of atoms in the sampled molecules. Can\n",
-      "                        be a single number or a range, e.g. '15,20'. If None,\n",
-      "                        size will be sampled.\n",
-      "  --output OUTPUT       Output file.\n",
-      "  --n_samples N_SAMPLES\n",
-      "                        Number of sampled molecules.\n",
-      "  --batch_size BATCH_SIZE\n",
-      "                        Batch size.\n",
-      "  --pocket_distance_cutoff POCKET_DISTANCE_CUTOFF\n",
-      "                        Distance cutoff to define the pocket around the\n",
-      "                        reference ligand.\n",
-      "  --n_steps N_STEPS     Number of denoising steps.\n",
-      "  --device DEVICE       Device to use.\n",
-      "  --datadir DATADIR     Needs to be specified to sample molecule sizes.\n",
-      "  --seed SEED           Random seed.\n",
-      "  --filter              Apply basic filters and keep sampling until\n",
-      "                        `n_samples` molecules passing these filters are found.\n",
-      "  --metrics_output METRICS_OUTPUT\n",
-      "                        If provided, metrics will be computed and saved in csv\n",
-      "                        format at this location.\n",
-      "  --gnina GNINA         Path to a gnina executable. Required for computing\n",
-      "                        docking scores.\n",
-      "  --reduce REDUCE       Path to a reduce executable. Required for computing\n",
-      "                        interactions.\n"
+      "[02:57:03] Explicit valence for atom # 42 C, 5, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 180\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 42 C, 5, is greater than permitted\n",
+      "[02:57:03] Can't kekulize mol.  Unkekulized atoms: 7 13 26 34 39\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 406\n",
+      "[02:57:03] ERROR: Can't kekulize mol.  Unkekulized atoms: 7 13 26 34 39\n",
+      "[02:57:03] Explicit valence for atom # 38 C, 5, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 713\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 38 C, 5, is greater than permitted\n",
+      "[02:57:03] Explicit valence for atom # 11 O, 3, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 1283\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 11 O, 3, is greater than permitted\n",
+      "[02:57:03] Explicit valence for atom # 9 O, 3, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 1778\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 9 O, 3, is greater than permitted\n",
+      "[02:57:03] Explicit valence for atom # 19 C, 5, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 1844\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 19 C, 5, is greater than permitted\n",
+      "[02:57:03] Can't kekulize mol.  Unkekulized atoms: 6 8 42\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 2003\n",
+      "[02:57:03] ERROR: Can't kekulize mol.  Unkekulized atoms: 6 8 42\n",
+      "[02:57:03] Explicit valence for atom # 3 O, 3, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 2091\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 3 O, 3, is greater than permitted\n",
+      "[02:57:03] Explicit valence for atom # 17 O, 3, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 2525\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 17 O, 3, is greater than permitted\n",
+      "[02:57:03] Explicit valence for atom # 24 O, 3, is greater than permitted\n",
+      "[02:57:03] ERROR: Could not sanitize molecule ending on line 3868\n",
+      "[02:57:03] ERROR: Explicit valence for atom # 24 O, 3, is greater than permitted\n"
      ]
-    }
-   ],
-   "source": [
-    "# All Options\n",
-    "!python /workspace/src/generate.py --help"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a1a9c2b",
-   "metadata": {},
-   "outputs": [
+    },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO2dd1xT1/vHnwQCyAgoSywggoooTtzgRm0tbhFti3VGbSvOGtuf38Zaa7FqpWrVaFtFa0estsVVRasVUKERFAeIDBcbBGSElTy/Pw5ewlBRktyQnPeLP8i5957ziYZPznweDiIChUKhUF4XLtsCKBQKpWVDbZRCoVCaBbVRCoVCaRbURikUCqVZUBulUCiUZmHItgB2yMrKEovFmZmZ77zzztChQ9mWQ6FQWjAcfdvwlJmZKRaLv/3226dPnyoUCgBo27Zt3759fXx8vL29BwwYwOPx2NZIoVBaEnpkozExMd98883Ro0erq6sBwMXFRSaTlZaWlpSUMPfw+Xxvb28fH58hQ4b069fPxMSEPb0UCqVloPs2qlAoTp48uX379nPnzgEAj8ebNGnSypUrBwwYQG5ITU2NjIyMioqKjIxMSEhg/kEMDQ179uxJXHXkyJHW1tasvQcKhaLF6LKNlpSU/Pzzz9u2bUtMTAQAPp8/e/bsVatWOTk5Pe+RrKys//77j1hqTExMVVUVc8nV1ZVY6ujRozt06KCJN0ChNI2VK1f269dv5MiRdnZ2bGvRR3TTRrOysvbs2bNjx44nT54AgKurq0AgWLRokaWlZdMrKSkpuXr1KumoRkVFyWQy5pKDgwOZS/Xx8enduzeXSzc8UFijuLjYw8MjMzPT3t7ewcHB0dFx9uzZkydPZluXHqFrNvrnn3/+9NNPYWFhpCPp4+OzYsWKiRMnNtPpqqurb9y4QSz1n3/+yc/PZy5ZWFgMGDCAmVE1NjZu7nugUF6F2NjYIUOGlJWVMSVCoTA4OJhFSfqGTtlodXW1nZ1dQUEBl8sdN27cJ598MnjwYHU0xEynhoeHp6WlMeU8Hq9Hjx6+vr7EVVu3bq2O1ikUZfbu3btw4ULmpbW1dUxMjKurK4uS9A2dstHs7Oy2bdsCQHh4uK+vr2YaffDgQURERGRkZGRk5J07d5h/TwMDg549e/bp08fS0nLu3Lldu3bVjB6KvrFw4cK9e/cyL/v37x8dHc2iHj1Ep7bf29vbe3h4JCQkJCYmasxG27dv3759+/feew8AiouLo6OjSUc1IiIiNjY2NjYWAHbs2HHmzJnhw4drRhJFr8jOzlZ+2aNHD7aU6C26tjayevVqAAgLC2OldQsLC19f33Xr1oWHhz958uTChQvvvPOOkZFRZWXlunXrWJFE0XmUZ+rNzc0XLFjAohj9RNdsdNKkSTwe7+LFi2SNnkVMTU2HDx9++PDhDz/8EACUN/lTKCpE+aPeoUOHfv36sShGP9E1G7Wysho2bFhVVdXx48fZ1lLD7NmzgdooRT0UFBQUFRUxL7t06cLhcFjUo5/omo0CwNSpUwHg6NGjbAupoUuXLkZGRsnJyco7TykUlZCUlMT0Rnk83rvvvsuuHv1EB2108uTJBgYGZ8+effr0KdtaAACMjIw6deokl8sTEhLY1kLRNf777z/m69nFxeWtt95iV49+ooM2am9vP2jQoIqKitOnT7OtpQZPT08AuHXrFttCKLpGXFwc83vnzp2NjIxYFKO36KCNgvaN64mN3rx5k20hFF0jNzeX/MLlct9++212xegtummj06ZN43A4J0+eVD4hxyLdu3cH2hulqAFmt5Ojo+OMGTPYFaO36KaNOjo6enl5lZWVhYeHs60F4JmN0t4oReUw60tubm708DFb6KaNgpaN6zt06GBhYZGenq68U5pCaSa5ubnMbqchQ4awK0af0XEbPX78eGVlJdtagMPheHh4AMDt27fZ1kLRHe7evUt6o7a2tnPmzGFbjv6iszbaqVMnT0/PwsLCCxcusK0FgE6PUtRATExMRUUFALi5ubm4uLAtR3/RWRsFLRvX0z1PFJUTHx9Pfunduze7SvQc3bfRP/74g+SwYxe6ykRROXl5eQBgaWlJw5Gwiy7baPfu3d3d3fPy8iIjI9nWUrt1VJcCvFLYhaxYtm/fvlevXmxr0Wt02UYBYNKkSQBw7NgxtoWAvb29nZ1dUVHR48eP2dZC0RHI+lK3bt1oOBJ20XEbJeP6Y8eOaUMfkE6PUlRIZmZmUVGRsbHxrFmz2Nai7+i4jfbt29fZ2Tk9PV0b0irQ6VGKCrl7925+fr6Li8uoUaPY1qLv6LiNcjgckmlWG8b1tDdKUSFXr16trq7u3Lkzj8djW4u+o+M2Cs/G9b///jvbQmiAEooquX37NpfLJbP/FHbRqcygjaJQKBwdHTMzM+Pi4thd0CwpKeHz+UZGRiUlJYaG2pFMUCYDmQz4fNASPZQmM27cuISEhPj4eAsLC7a16Du63xvlcrkTJkwALRjXm5ubu7i4VFRUJCcns6sEACA8HAYMADMzsLYGPh8CAuDhQ7Y1UV6B/Px8Nzc36qHagO7bKGjTcSZtWWU6dQreegv69IGYGMjIgD/+gORk8PGBvDyWhVGaBiJmZGQMGzaMbSEUAD2x0eHDh7dp0+bOnTuJiYnsKtGKVSaFApYuBV9f2L0b+vYFBwcYOxZOnoT8fNi0iU1hlCbz+PHj4uLiuXPnsi2EAqAnNsrj8caPHw9aMK7Xit5oQgIkJ8PixXUK27aFadMgLIwlTZRXIzEx0crK6o033mBbCAVAT2wUtGZcrxWL9ampAABubvXLO3aE1FTQ9SVH3eDKlSs0ZYj2oC82OmbMGD6fHxsbm0pMhCXc3d2NjIxSU1NLS0tZE0GMsuHSvJFRzaVNm+CLL+Dvv4EGmdZW4uPj33nnHbZVUGrQFxs1NjYmuWf//PNPFmXweDx3d3eFQsFmsmUyEnz0qH75gwfQrh1wOPDdd/DZZ/DWW2BjA+3awfjxsG4dHD8Oz/JVNAWFAlJT6y9ZZWdDdnYz1VPg2rVrp06dGjZs2OjRo7/99lsapYF9UG+QSCQAMHjwYHZlzJw5EwB+/PFH1hRUVqKtLc6bV6dQJkMHB5w7FxUK/PlnXL4cfXzQzAwBan+4XOzaFd9/P+2H81evYnn5ixopKEAAdHLC4uLawkmTcPp0tbwnveKrr74CACYcCYfD6du37/r162NjY5vyeEVFRVpa2uPHj9WtU3/QIxstLi42NjbmcrkREREsyti4cSMArFixgkUNGBKCPB4ePowKBSJiSQnOnYutWmFiYp3bqqvx1i0MDcWgIPT2RhMT4qei4RcB0NAQu3bFwEAMCcGICKyoqPMosVETE1y5sraQ2qhKiIqKAoBevXqFhob6+/srbx21s7MLDAwMCwsrb+xbrqioaN68eaampuRmV1fX48ePa16/7qFHNrpv3z4Oh2NpadmqVauQkBAFcRCNExYWBgCjR49mpfUaFApcvx5NTJDPRw8P5PHQ2Rn/+eclT5WXY3Q07ty57eP0bt3QwKBOV9XUFH18cNkyPHwYk5JqbHT1ajQ0xOvXayqgNqoSSJhRCwsL8lImk4WHhwcFBTk6OjJ+ampq6ufnJxaLMzIyyG3V1dVDhgyxtbX95ZdfMjIykpKSRCLRwIEDq6qq2HsrOoK+2Oj333/P5XIBoE+fPuRz9vbbb2dlZWleSVpaGgA4ODhovmlERLm89vcnT/D0aZRIMCoKX/1vqbgYIyIwJAQDA7FrV+Rwai3V2bnGRs+fx7ffxn79apqlNqoqrK2tASAzM1O5UKFQSKVSkUjUp08fZsjP5XIHDx587do1sipw5MgR5Ufkyp8HyuuiFza6b98+4qEbN25ExKNHj5JPoa2t7Z9//qlhMQqFgs/nA0BOTo6Gm0a5HMeORZEI1fDHk5eHf/+NX3yBEybgokW1NpqUhCYmuHs3IrVR1TFo0CAAuHjx4vNuyM7OJkN+MzMzALh///4HH3xgbW1NfVMd6L6NMh761VdfMYVZWVnjxo0jX9eBgYHFyusg6of8DVy4cEGTjSIi/u9/CIAODpibq+6mGBtFxM8+w9atMSeH2qjKmD17NgDs3bv3pXeWlJScPXsWEf38/Pr27at+afqIjm942rdv38KFCxUKxVdffbVmzRqm3N7e/sSJE2Kx2NTU9NChQz169CDT9pqBnU34Fy7Axo3A5cLBg2Bjo8mW16yB1q3hs8802aaO07lzZwBISkp66Z1mZmajR48mvz8v18jGjRvnzp37/fff3759W6FQqFCnvsC2j6uRvXv3cjgcDocTEhLyvHtu375NktMaGhoKhcLKykp1q5LL5YGBgQBga2s7efLkpUuXbt269bfffouKinr8+HF1dbU6Gn2SkYHt2iEAfvGFOupviHJvFBFPnkRDQ/TwoL1R1UDi506YMKHpjyxcuNDOzq7RS8oBJC0sLLy9vYVCYVhYWH5+vor06jg6a6NisZh46LfffqtcXl1dvWLFiocPHzIllZWVIpGIDPwHDBiQlJSkPlWXL18ePHgwABgZGT3vi61169ZeXl7+/v5BQUHBwcESiSQiIiIlJeW1Z7WqqqqGDh26qHv30oAAdcyKNko9G0XEyZMRgNqoaiBDGXd396Y/8ttvvwHAqVOnGl7677//QkJCAgICnJyclD+KBgYG3bt3X7hw4YEDB+7effrSJsrLUSjEffvqFB46hD/91HSZLRLdtNG4uB8MDLgcDmfHjh31Lm3ZsgUArKysfv75Z+Xyf/75h3yGLCwsxGKxyiUlJib6+/szX/h9+vSJioo6cuTIN998s2zZsqlTpw4YMMDBweEFKR5NTEw6deo0YsSIWbNmrV27ds+ePSdPnrx582ZhYeGLm/7kk08AwN7evt7CrlppaKMPH6K5ObVR1SCTyQYNmjJy5NqmD58qKyt79uzp4uISERFBNjndvn379OnT9W7LyMgICwsTCoXe3t4mJibMx8/OTs7no68vikQYFoYFBY00UVRUc0rj8uXawilTcNq013qTLQcdtNHs7O1SKef48eE7d+5seDU3N5fJu+Dv7688bCksLHzvvffIpSlTpuSqaB0mLy9PKBSS7qeZmdlHH33Upk2b560vVVZWpqenS6VSiUQSEhIiFAr9/f29vLxe6rCurq6+vr6BgYFCoVAsFoeFhUml0qKiolOnTnG5XAMDg3Pnzik3tGHDhl9++UUlb7BRFAp88qT+NqqiIiwpUV+b+oWLCwLgK42dMjMzyZFoExMTS0tLAwODDz744AX3y2SyyMjILVu2BAYud3Cos03Y0BC9vPCjj/DwYUxLq7mf2Gi3btizZ+1/PbXRlkdOzm6plCOVcrKz6/dDlQkNDTU3NwcAZ2fneo4mkUhat24Nz5ahmiOmrKwsODjY0tKSzL0KBILMzMzx48d37NjxNeZAy8rKEhISwsPD9+/fv27dunnz5o0dO7Zr167kjTwPcsRFJBIpV3Xjxg0yiTFz5syCRvsVqiYiAvv3x/nzNdCUvjBmDALga5xCysjIuHTpklQqffLkySs9mJaGhw/jRx+hlxcaGtZxVQcHnDGjxkYPH0YrK9y6teYpaqMtjOzsbcRDc3Ia6YfWIy0tzcfHBwA4HE5QUJDy4bkHDx4MHz6cXBIIBKWlpa+qRKFQSCQSFxcX4mW+vr7x8fGIeObMmTZt2kycOPFVK3wxZWVlKSkp4eHhoaGhwcHBAoHA19eXOKyrqysAdO7cOTo6WvkR5ovEycnpn5eeX3p10tNxxw789deal9evIwC+8YbK29FflixBgFq30jClpTWHL/z90dYWAXDQoBobPXsWt21Dc3MkCxDURlsSWVnfSKUglXJycr5r4iNVVVXBwcEkP62np+eNGzeYSwqFIiQkxNjYGAA8PDyaGPSBcO7cObL6DwBeXl6MSVVVVfXu3ZvL5e7fv7/ptTWTmJgYsg7bcCtCamrqkCFDmvNt8QL++gsB0Nu75qVCgWRUePu2ChvRa7ZvRwBcuJBtHYiIePcuxsTU2mhVFXbvjpMnIz6z0fR07NsXp0zBpUtx2zY8ehT/+w/ZOEWoFnTERl/DQxmio6PJLjwTE5Pg4GDlBfGbN2/26NEDAHg8nkgkeulIPCEhgVlHcnR0FIvFyo98+umnhoaGLi4uT5++fNFThZSXlwuFQjKK79+//927d5lLVVVVn3/+OUlTGhBwTOl7pLk8fYo8HhoaIrMAFhiIALhtm8qa0HPOnEEAHDGCbR1KMDaKiJGRyOHg6dM1NhoVVWcSgPkxMcERI8b7+vrOnTt33bp1Bw4cOH/+/L179xoNraK16IKNZmVtfeahu16vhrKysqCgIGYArhxDTCaTMR40ePDglJSURmvIzc0NCgoifmRubi4SicrKyuqKzCLj65EjR76eyGYSFRVFBDSMzBIdHT1y5AempmhsjJs3q2xP1Lx5ezp37nH06DHy8uBBBMBx41RTOSUtTevmSZRtFBFnz8Zu3XDCBJw2DUtL8coVlEhwyxYMCsKJE7F3b7S2RgDk8y0bzuk33KqozbR4G83K2vLMQ3c3s6rTp087ODhAY9uhzp49S/Le8Pn8gwcPKl8qLS0NDg4mx+R5PJ5AIGg04glz9nTdunXN1PnaFBUVCQQCImPs2LHp6enMpbIyDAqqCS8yeDAmJ6uguS+++AIAFi9eTF5mZWHv3hdGj/60ZXU0tBa5HFu1Qg4HNTu2eRH1bDQ7G1u3xlatXjQ3Wlpas+9KLBavXbs2MDBw6NChHTp04PF49f4GtZkWZqNlZfHZ2dszMtbl5x+qqsotK4uXSrlSKTcvTzVRkLOzs0nyOwAIDAxUHn0XFBSQiMvMTim5XC6RSNq3b890Y2/evNlotX///TdZ/be1tb1//75KpL42EonE2tra0NDEx+dJvcAsZ87UnHXi87H5e2djYmIMDAwCAgKYkp49ewLAeeXdpJRm4OmJAHjtGts6nlHPRhFx1y4EeJ0lJrlcroEjhaqiJdloVtYWqZSbmDg4OXnK7dueKSnTEDE3d29e3n7VNhQaGkri4ri4uFy6dEn50vfff08WuNu2bduxY0dioP379693mzJVVVVMdL4BAwaoVurr8ejRI4HgCpmcWrCgToB6EkCEXGrmKrBcLq+3pebjjz8GgDVr1jSrXsozpk5FAFTn9t9XQyZDgQDv3Kktkctx1Srcs4c9TRqhxdioXF527RovI+ML5RL1NZeQkODl5QUABgYGQqGwQim2e1pa2pAhQ1q1asXj8ZycnMRi8YuPaX7yySeGz/LHLViwQH2aXwmFAsViNDVFAHRxwXrfAqGh6Oqq+oXUs2fPkt0LKq5XpZSVYXAw1uunHzmCf/3FkqDnc+wYbtqECQls62hAZSVKpSiVsq1DU7QYGy0vT5JK4cmTIy+/VUVUVVWJRCIDAwMA6NevX70F7latWgHAS086ZWRkkIUdsvR09epVNat+NW7fxt69aw6lCIV1EoGoIya6TCZr1aoVl8vNzs5Wfe0qIjcXAdDYuI49+fnhzJnsaWpAfDyKxagUGQLLy+uXsEhmJgJg27Zs69AULcZGFYqKGzccbtxol5//i1wu01i7ly5dIrvozczMzpw5w5QTc7x3796LH2dWlsjWVLYyl7yAykoUiWoygvTrVz8bk0ooKCiIiIgICQkJDAzk8/kGBgZvvvnmDRXurlIpxEbbt0df39pCbbPRrVsRAMeOrS3Jz0cAbHBEnh3Iv6GNDds6NEWLsVFELC2Nu3t3mFTKiYuzevhwSXX1qx1le23IArednZ3yEjwJvRwZGfmCB0+dOkVWlgjTtPgwx8WL2L49AqCZGf7yC/r5IYdTJznT778jwEuygRKqq6tTUlLCwsJEIpGfnx/TGWdgUgaNGjUqLCxM2+KxEwv44Qc0Nq4NTaSFNmplhWZmKJHUlGiVjZLANFZWbOvQFIYNd2xpLaamvTp3vlhZ+SA//1BW1lcy2Z3Onc9poF0+ny8Wi9evX29vb88Ukt+zn592vbKy8pNPPikoKCAvDQ0NmZ35WsiwYRAfDx9/DD/+COQIq4EBLFkCcXHA473k2adPIT4ebtyAGzfg+nWorJx/48YB5Rv4fH6PHj169uzZs2fPXr16mZmZHTx4cO/evefPnz9//rybm9uCBQsWLlxoZWWlpnf3Gri5wfLlsHIlvP02aJOuWiwtYdYsWLYMxo4FPp9tNXUhawHV1Wzr0Bhs+/hrkpOzRyqFqiq1J8N4HgsXLgSAXbueu+F/9erVZF6V4ObmptrTlmqCLLP6+eHUqWhnhxs31pQr90bT0zEsDIODa5LZcbl1zqUMGRLq4ODg5+cnFApDQ0Nv3brVaH/z6dOnYrHY3d2d/Pvw+fygoKA0JlgQe5De6MWLWFyMTk64aBGiVvZG27fHkhJ0csIlSxC1rDcqk9WcUNITWlJvtC4IwOVyTV5+o3p4cW/00aNHR44ckcvlTImbmxuTH1yb8fCo+YXPhw0bYOlSCAgA5XG5iws8eFDnEWNj8PSEnj2Zn3etrGa9tCELCwuBQDB//vyTJ09u37793Llz27dv37lz57hx45YuXerr66vCN9V0Kipqfzc3h23bYPp0mDu3tlChAK7WZN4xM4OtW2HGDHj3XejUiW01SpD+g9LHX8fRmk/EyygvT0hKGpmbu7uo6HROzo6MjP+1bj2Zy31RjDi18mIbLS8vd3Nzs7W1ZUpGjhypIWWqY9486NYNliypU+jsDK1bg7c3BAVBaChIpVBUBFIp/PADBAXBsGFgZWXwnPoagcvljh8/Pjw8PC4uTiAQGBkZnThxYvTo0V5eXnv37i0vL1fxW3oOCgUcPw6jR8Ps2XXKp06FMWNg5UpABADIzYUOHWDNGnj8WDO6Xo6/P7z5Jnz4ITAplEpLobKSVU10UK+1VFZmpKeLEhOH3rzZ4c4dr/T0tdXVTxFRoahU6wbS50GS4UwmQWyeQ0JCQkBAQMeOHTUceb75+PnhnDmIiDExyOXi0aO1g3q1xl3OysoKDg5u164d+XC2bdtWJBKpKn52o2Rn44YN6OhYMyNhY4MPH9YM6gn37qGJCVpZ4cyZ+N13NbcZG+OsWfgqYb9UgFyOYWHo7Y1RUTWDekJSEhob47ff1gzqP/8cW7dGgQBv3dKovHqQvR/qSS2mdbQYG22UiopHiYneqakszFpFREQAwODBg196Z15e3g8//KABSSqEsVFEXLQIO3TAn35q6kp98ykvLw8NDe3evTsxU2Nj48DAwOcdtH1trl1DgQBbtapxxk6dMDgYCwpq50YZPvsMAWrmRqVSDAysDVrs5YWhoWrZY6tMQQF+/TU6O9c0+v77dWwUEf/3P7SxqbFRP7+a2zgc9PVFiaTOdmCNYWysuQ8M67RsG5XJEuPiLKRSyM39XsNNk9y2rq6uGm5XMyjbaH4+2triwIEs/FVERET4+/szK3Xe3t5hYWHN3HtbUYESCfr61ngNl4u+vhgWhkythYXo64vKu1rLynDSJPzyy9qS1FQUCrF165pKOnTA4GB8xVjyTSI5GYVCtLKq9fqQECwtrW+jZWXo6lq7xCSVokCAZmY1T7VujUFBqgk303TIAbmWsKqqAlq2jSJifv7PUinExpqUlmp0iFVUVAQAZmZmmmxUYyjbKCL++GPNHyQrnYvk5OSgoCAS5QAAOnbsGBISUvLqkwsZGRnr1wc7OSnIe2nTBletwtTU+reVlTXVcYqLUSxGD4+afxxz8/onyptDRAT6+9cMjUkAbGWv/+kn9POrc/+pU+jlVSeXXFERisXYqxc7nVM+HwGwqEgTbbFOi7dRRLx/f4FUCjdvdqyufkmOTNVCVt5f4+9Z+6lnowoFDhvG8hitqKgoJCSEiadlaWkZFBT04MGDpjwrlUoFAgHJc+ntnerujiEhjUzypqejSIQ2NvhKAWTkcvzzTxwxosatPDziJk6c+Np5WcrLy3/9Na1nz5raWrXCBQuaO8t5+TLOnl3TPQTAt96SrFmzJlnNvdOxY0OHDBHn5WnuwCGL6IKNyuWyO3f6SKWQkuKvyXbJIdHnBXJu0WRmYk5OnZKiIkxJQdbPssrl8rCwMGY7lIGBgZ+f3/POkslksv3795MQMwBgaGg4bdq0S5caGbWcP4+TJ9d2/fr1w5dlrW6E69dxzhwcNmwOaa5nz54//vhj04Or5uTkBAcHv/HGG46OPgYGaG+PIhGqcHWtoAB37EBPT+zatT8AcLlcX19fiUSipnh0dnZ2AKDNwRNUiC7YKCKWl9+Li7OUSuHFCUFVy4ABAwDgsvI4iqIprl27FhgYyHt2xMrLyys0NLTq2VpPRkaGSCRiNpxZWVkFBQU1jPQqk2FoKPboUeOeRkbo74/h4c0Slp2dHRwczBx4tbOzEwqFyvkUGhIfHz937lwmKXyfPn1++y1HfUNv0jdnJkns7e2FQmGjvYHCwsJdu3YtXrxYIBDs2rWrWDmi4ssgEdAzMjJUJ1x70REbRcQnTyRSKVy7xisp0ZCvTZgwAQD++OMPzTRHacijR4/WrFnTpk0b4gjOzs5BQUFTpkxhIhN6eXnt379fJqs/tExOTt6w4TSzdOPggJ9/jirck1ZRUSGRSMgXLQAYGRn5+/vXi++lUCjCw8P9/Pw4HA7pHvr5+YU308WbTGFhoVgsJoG0G+2cxsbG2tnZtW3bNiAg4P3333d2dnZzc2s0s0OjODk5AcBDLQk5pWZ0x0YR8eHDJVIpxMc7V1XlaaC5BQsWAMAenY9Jq/WQDVLdunUDAGKpPB7P39+/UUtiVv+Njfm2tnKyY0l9cdZJc4yte3t7SySS4uLi0NDQrl27kkJzc3OBQJDAUtzQyMjIWbNmkcCPZK/uwYMHq6qqOnbs2KtXLyYBhEwm27dvX9PjyHTo0AEAUhsu4ekiOmWjCkVlQsIgqRTu3fNDVPs03tq1awHg888/V3dDlKZAcmIDgKOjY8OxZFFR0Y4dO5gj/CYmJnPmzImLS2+0KpWTkpKybNky/rMIIkz32cXFZevWrYWvMRGrapQ7p3/88QcJsH38+PHXrrBTp04AkJSUpEKRWotO2UrzIUUAABIDSURBVCgiVlQ8uH7dWiqFrKyv1d3Wjh07AOCDDz5Qd0OUJpKYmAgAnTp1Ui68d++eUChkIhY6ODiIRKKceitoGoFEY2nbtq2lpaWTk5PyZK72EBkZWVVVtWnTJgAoasZ+pS5dugAAW11sDdNyQ5M0jpGRs4tLaHLy+PT0T83MBpqbD1FfWy+NlUfRMJaWlgBAtvQS8vLyunXrVllZCQDDhw//6KOPJk6cyAyxNQyJxlJeXr506dIZM2bMmvXyAC6ax9vbGwCKiopatWrFbywAX0VFBY/H474sQAv5R67Wj3P1LSY0SdOxtHy7bduPEavT0t6prs5VX0PURrUN0uUsLCxkSmxsbGbOnCkQCOLj4y9cuDB16lS2PJSBdNPu3r3LrowXY25uLpPJSktLG17atWuXvb39+PHjN23adO3atefVoFc2qmu9UUK7dl+WlFwpKYlITZ3RqdNZDucVYg41HWqj2oaxsbGxsXFFRQVJ+kQKDxw4wKooqKysvHPnTkVFBVm4JzZK5h+0Fk9PTwCIjY0dMqT+eO7GjRt5eXknTpw4ceIEADg7O48aNWrkyJGjRo0im5wI5AivXE+C5bE9q6AuKisfX79uGxvbPjR0s5qaIJHt+Xy+muqnvAbku02rtitGRUUBQN++fclLhUJBzr8VFBSwK+wFyGQye3v7kSNHNjp7m5KSIhaLAwMDmVhcBFdXV4FAIJFI8vPzyXeGtuVwVBMcJJEUdZHMzAv9+k3Jyio+e/asmsJ9tmrVqry8vKysjOn7UNjF3d09KSkpISGBdPq0gSdPnlhbW1tYWBQVFZEtor169bpx40ZMTEy/fv3YVvdc/v7778mTJ3t6ek6YMMHe3v7mzZuXL1/+77//lGdFFQpFfHz8+fPn//nnn0uXLpWUlJByAwMDIyMjmUx27ty5UaNGsfQONIcOzo0yODiMmDcvSC6Xz5w5MyMjQx1NkHMyOTk56qic8hqQhE7K06Os06ZNGxsbm+Li4szMTFLSIsb1b7755vXr1729vc+fP//rr7+WlpauX7+efA0wcLncXr16rVy58uTJk4WFhVKpNDg42NfX19DQUCaTmZqampuzFlhdo7DdHVYvcrl8zJgxADBs2DB1bC7p27cvAERHR6u8ZsrrQf67T2tJTqJnkOVvJl7JZ599BgD/93//x64q9VFaWhoSEtLEwDE6gC73RgGAy+UeOnTojTfe+Pfff0Ui0WvXk5mZeezYsRUrVgwdOrRSKUUDXWXSNhruedIGyLZ/ZnW+3kvdw9TUdOnSpc7OzmwL0RC6uVKvjJ2d3c8//zxq1Kivvvqqf//+EydObMpTCoUiISHh2rVrUVFRkZGRZBcxuRQbGztw4EDyO7VRbUMLB/Wgfzaqb+i+jQLA0KFD169f/+mnn86ZMyc2NpYEuGtIcXFxdHT05cuXL1++fOXKladPnzKXLCwsBg4cOHjw4MGDB/fo0YMppzaqbbSU3iiHw7l3755cLlfOwk1poeiFjQLAmjVroqOj//rrr4CAgIiICCMjI+bSgwcPtmzZEhkZefPmTeVtbi4uLt7e3oMGDfLx8fH09Gz0405tVNvQThutt6Zkbm7erl279PT0hw8fkhAelBaNvtgoh8PZv39/nz59YmJiPvnkk61btzKXEHHnzp0AYGho2LVrVx8fH29v76FDhz6v00pIS0uLioo6efIkAFy/fl3N8ilNRTsH9a6urjwe78GDB+Xl5SSuqLu7e3p6+t27d6mN6gJsr3FplOjoaCMjIw6H8/vvvyuXf/PNN//++2/pC/NvVVVV3bp1i+w6ZlJZwLMDiBs2bFCzdkqTOHToEAC88847bAupT+fOnQGAyW+6ePFiAAgJCWFXFUUl6EtvlNC/f/9NmzYtX758/vz5vXr1cnNzI+XLly9v9P78/HwyVRoVFSWVSmUyGXPJxsaGTJVWVlauX79+7dq11dXVzdkMQFEJ2jmoB4AuXbokJSUlJiaSc5Z0lUmX0C8bBYBly5ZFRkYePXp0ypQpV69ebXj6KDU1NTIykqzRx8XFKRQK5pKrq6u3t7eXl5ePj0+fPn2Yrcju7u7vvvvuunXrZDJZcHCw5t4MpQHaOaiHBr7ZInbgU5qI3tkoAOzfv//WrVvx8fErV67ctWtXVVVVfHx8ZGRkVFTUxYsXc3Nrg0LxeLzevXt7e3v7+PiMGDHCxsam0QqnT58OAO+++y6J0kidlEW0tjdK9zzpMmzPKrBDbGwsmenv3LkzkxaN0K5du2nTpm3bti06OvqVkiZKJBISHGz16tXqU055MQ8ePAAAR0dH5cKsrKymZ79QExEREQDQv39/8lIul5ORUHNCI1O0BD21UUT89NNPSfpGAwODrl27BgYGisXiW83LCH7kyBFiyh9//LGqdFJeCdIPNTc3Vy4cPHiwm5tbcHBwfn4+W8JI4AVLS0umhGxAlkqlbEmiqAr9tVGxWAwAY8aMYZJ2qYTff/+dOOmqVatUWC2liSgUCgMDAw6Hw4RQyM/PZ3ZWmJubL168uJlflq+NtbU1AGQ+S0Dq7+8PAD/99BMrYigqRMfP1L8AMi01YsQICwsLFVY7derUY8eOGRsbb9myZdWqVSqsmdIUOByOhYUFIjKrTG3atElNTSWpjEtLS3fv3u3p6enj43PkyBENx2ZfsmTJhg0bmHMcdHpUd2Dbx1lj3LhxoLYs8ydOnDA2NgaAFStWqKN+ygsgR9RmzpxZUVFR79Ldu3eFQiFZzQeAdu3aiUSi3NxcVnSSLa7Tp09npXWKCtFfGyWbRu/cuaOm+k+ePEmcdPny5WpqgtIob7/9NnHJtm3bCoXCR48e1buBZOhk0sQbGxv7+/tfvnxZwzojIyMBwMnJScPtUlSOntpoRUWFoaGhoaFheXm5+lo5deoU2Q+wbNkyhUKhvoYoyuTn58+YMYOJ0mZsbPzee+81zGahUCjCw8P9/f2ZUbaXl5dYLJbJZBoQKZVK+/TpAwA8Hk8DzVHUip7a6K1bt6BBQnN1cPr0aeKkixYtok6qYSIiIvz9/ZlUoMQly8rK6t2WkpIiFArJ+g8A2NvbC4XChw8fqkNSTk7O5s2bycFQwkcffaSOhiiaRE9t9PfffweA8ePHa6AtxkkFAgF1Us2Tnp4uEomYoxN2dnZCofD+/fv1bpPJZKGhoUwURB6P5+/vHx4erioZUqlUIBAwp+YcHBxWr1595coVVdVPYRE9tdEvv/wSNLgn6e+//yZOumDBAtb3gesn5eXlEomEibfN5XL9/PzCw8MbfrFJpdLAwEDmUEbv3r3FYvGLw9a8gIKCArFYTM7Rk3Z9fX0lEok6UtpQ2EJPbXTWrFkAsG/fPo21eObMGdIToU7KLvVc0t3dPSQkpKSkpN5tGRkZIpGIpCwEAEtLy6CgoLS0tFdqqF73UygUvlINlJaCntro9OlZQ4fGR0WlaLLRs2fPkj+q+fPnUydll8zMzODgYHKMDQD4fL5AICCpYpQpLy8/cOAASVwIACYmJoWFhS+umXQ/u3fvTruf+oOe2qiVFQJgTo6m2/33339Jytl58+ZRJ2WdiooKiUTi6+urbHlhYWGNjvQFAsHcuXNfUBu5x9TUlHY/9Q19tNHMTATANm3YaZ1x0rlz51In1RKuXbum7IAdO3YMDg5+8uRJU559XvfzleLaUFo0+mijFy8iAA4axJqAS5cuESedM2cOdVLtoaCgICQkhDmAb2FhIRAImHj1DWm0+5mamqpJzRRtQB9tdM8eBMA5c9jUEBERQc7yz5w5s7q6ut7V+/fv08EgW8jl8rCwMF9fXyYst7e3t/LkZmFhoVgsZrZG0e4nRR9tdPlyBMDgYJZlME46Y8YM5fWH5ORkJycnNze39PR0FuVRbt68uXDhQjMzM2KXNjY23t7eHh4eZO8aALRr127t2rUNt6BS9A19tNFx4xAA1ROT5NWIjIwkThoQEMAcSy0qKurXrx/Zi5OVlcWuQkpRUZFYLPbw8GDOHdHuJ6UeHEQEPcPNDVJTISEBunRhWwrA5cuX33rrradPnzo5OSUlJZGeTmFh4ciRI+Pi4nr27HnhwgWSfJTCItXV1V9++eWFCxcQcdOmTcw2fgoFAPTORisqwMwMOBwoLQUjI7bVAADAkSNHAgICENHX1/fMmTNcLhcAcnJyhg0blpiYOHDgwPDwcLIkRaFQtBC9C9t87x7I5eDqqi0eCgD+/v579uwxMzM7d+7ckiVLyBebnZ1deHi4i4vL1atXJ02aVF5ezrZMCoXSOHrXGy0shPBwUCggIIBtKXWJiooaO3ZsaWnpsmXLtm3bRgqTk5OHDh2amZk5YcIEJj0JhULRKgzWrVvHtga18/QphITAkyfg7g4mJtCtG3h6wq+/wqNH0KkTXL0Khw+Dj0+dR777DoqLwdVV7doeP37M5/MBwNnZuW/fvkeOHImKijI0NBw6dCgAtGnTZuzYsRKJ5Pr169nZMG7cCK7ejR8oFK2HxeUtjfHgAQKgsTEmJtYWjhyJ8+YhIn7zDfL59R/p3BmFQrUL2717t4mJyYkTJ5iSY8eOkfiYmzdvZgrj4uI8Pcc7OVXOno000h6Fom3oUd/GyQmWLGFbRF1SUlLKy8v9/f0vXrxISiZPnvzDDz9wudzVq1fv3buXFPbq1WvXrr/y83kHDsCKFayppVAojaJHNvr55/Dvv/DLL2zrUOLrr79etGiRTCbz8/MjmXkAYNasWdu3b0fExYsX//JM7pAhnL/+AhMTCAkBkYg9xRQKpQF6ZKOdOsGyZbBiBTzLvFuLQgEJCXV+Kis1IYnD4ezatWvevHmlpaV+fn6xsbGk/MMPP9y4caNCodiyJTosrGYN0NcXfv0VDA1h/XrYtEkT8igUSpNge1ZBE5C50ZgYLC5GR0dcvBix7twoAHK5dX4ANDE3Sqiurp4+fToA2NraKmcqDQ7+w9QUTUxQOZPFoUPI5SKHg7t2aUgehUJ5MXrUGwUAc3P45hsQi0EqrVPO54NcXudHKeeY2jEwMDh06NC4ceNyc3PHjBmTlpZGyoXCSYsXQ3k5TJwIERE1N7/3Hnz/PQDAhx/CDz9oTiSFQnke+mWjAODvD76+sGoV2zrqYmRkdOTIkaFDhz5+/Hj06NEZGXmkfPNmWLAAyspg/Pha658zBzZvBkRYtAiOH2dNM4VCIeidjQLAzp1w9SrExLCtoy6mpqbHjx/v169fu3brRo2yyc4GAOBwYPdumDEDiorgrbfg9u2am1euBJEInJyga1cWJVMoFAD9tNFOneDjj6GkpEk3P30K06aBlxf06QPh4eoVxufzT5/+p7DwvcREGDcOiooAAAwM4OBB8PODvDwYNQru3q25ed06uH4d3NzUK4lCobwUvbBRU1Pw94c2bWpLPv0UAgOBZCpzc4Nx4+o/MmpUTUfvwQOYMgWuXYPQUE1MBVhbm587B126QGwsvPlmjdfzeHD0KIwdC9nZMHo0PHhQczOfr3Y9FArlpejdmfrXJisLRoyAhARNtPX4MQwZAvfvw6hRcOIEkDDBJSUwZgxcuQLvvw8HDmhCBoVCaQp60RtVCV9/De+/r6G2HB0hPBwcHOD8eQgIgKoqAABzczh1CoKC4LvvYNMmCAiArKzaR6KjYfr0mjspFIomoTbaJLZtg7Q0ja7vd+wIZ8+CtTWEhcHMmSCXAwBYWcG334KZGURFgURSR8/jx3DkCCgUmlNIoVAI1EZfQnk5LFgAiYkgkYChoUab9vSEc+egdWs4ehTmz4d6sy8DBsBvv8G5cxqVRKFQGkJt9CX88gvExcG1azBoEPTtCxqOntyrF5w8CebmYGRU30Y9PGD+fPjgA01LolAo9aBLTC0AkjbqWbpfAIAJE8DaGjZvBnd3WLIE1q2Do0dh2jQoLwdjY/aEUih6Ce2NtgA8POp4KIONDWzcCMHBkJSkcU0UCuUZ1EZbNgsWQO/eNAgphcImml00oagaLhd27oQBA+CNN9iWQqHoK7Q32uLx8oJFi+DHH9nWQaHoK9RGdYGNG8HWlm0RFIq+Qgf1LZKpU8HUtPYlnw+hoXD+PBgYsKeJQtFX6IYnCoVCaRZ0UE+hUCjNgtoohUKhNAtqoxQKhdIsqI1SKBRKs6A2SqFQKM2C2iiFQqE0i/8H7HIDR/sjrE4AAAK1elRYdHJka2l0UEtMIHJka2l0IDIwMjMuMDkuNQAAeJx1j1tI03EUx3//65bbdM5tbjptwVySUZBiQbWd8xL0YIlhGSH9IRf/KOmhEiMfdAU1Lbt4ydS0NKKWPiiYRrn/yh7MtGxF+iCmlnZBK8oIIqS/mxcoO3D4nCvfc774moeJbBFk0ayy22QvpHgiyKTpfznbp1keEmUy/6U2xLk9ipmvK+fqihAX6vO5goizpOi/G4sCwQGGWiIgicHbFCEyIcqrJCeYLzylCD7KLP0jxcxTRShC0fIiYTjCLGMpJowQlrCcSLNKgeMFXiHSvNGqUAqKCGuYSggLF2mVWlBrRFoTLmi0Vm2kSGsNQqRO0JmsuiiRjtILeoNIG6MTGZOZmGOIeTlLxcSSWAuxxBFTHImNJ3pOVudlGYamOJ5jlQpOFRauUfORuii9QcubY2ItcaboYkq+kYScWGsyT2Ca4ZXzYFIdfNjtxvLTP5xUWg80pJSiy9vt/G16CnnbL6B4MXfzhPMxXFlVhPs+VzuuRp6HGZcHZ1wDvv1n6qElvRiF8UFJXVYCLq8bO99OS2mGLChsP4qTa1VSgGwDS8E5rGzdJI33T0IjVYsBMtw5VdcB6z31mNIw7bjxphz2tHhxaAAdvdllcMfRhNm5nPRkvA1u2xqxN3ujdDzrGVgzinBdJvjza+0w0nwXf02VSAnHHkFVtoQ7KldIz382w4b33fi9tEzW6oB8Sw/mjSj9hAxCAv8QH3B2/82aSfi6sh2veVi//d0odMAlNB9J8icnV8D1/CrsernXn9pXA58qXmBf72rJV98AGVv78cDhfscpzUloXTOAnRlGx61dqWDPGZPnk3wF39LhkGcMi9g2yXbPDRPOIezpqpbijU1gu/wRX+8869uSwEHO/QB63aNOT6ASjH8AtFHa9E/FWxkAAANAelRYdE1PTCByZGtpdCAyMDIzLjA5LjUAAHicfVZJbmQ3DN37FLqABXEQJS6y8NRGELgMdDu96Btkn/ujOfzS/8oiLhcsEU/kIx9JeD79+v5Q/Of761///FvWD70+mL39z6+qlp/UWnv4KH4oz2/vf97Ky9fT893y8vn37etHISwk9sY+O/bp6/PjboHyUqDX0SY3u1XponbgqoyzXZ6iA6WikgZQYaIdpBKCXoHkwFHH6COAXcZIIMvmkR04a6MZ5tq6/XUgUIYuL9/e/8A7vCcB4J5waijBlEfbCEgSgMEOfGyVsY3MaXa+IkcicaqbHy175R5IEhhX5MzgRISJVIgTVRpCV6SWH15Q1Hv0zjQCiTC3/KFleJldEjpogJ1GNTp9g4ZMWs14eIUUzJQT3XICLJ8ONf1a1InHmJGTdNyYApVbQbCkRAIJUymRreOGdKkM2akdTDsCRniZvDvt7tTUUdR7UtEfUpnnDhWDuqLSPetHqi3johGgHepKIdZJrFn/ppTt18beVTCdAFVN0Y2A0MGVSfaqqnvtFQAPr9Cj87p37wbFllCUaP9HtCad2dbDgBvUtUKugNHOBu3KKSu5VFcoHmll2xm0ZS8PGwaFDUo5LThBEipj5qSK4M6Vva7q86RZV9aRwk7ZWxBDLZNAY5i9WJGOVaBN3Ln6WBm00TF/3KJZ2aTIqdrHFUfip47EQ46/Zcv/SS0Us9R0Hi0DEm9sZIR3vqHYrAQR2xRj8D53FrNvXikUG9azcIwstojbbWTHNtwUiqlX4ZguHKGY6THbNl2EmRUx9NhuQyCna+RCWMi32+u2aHP1Pn/eXs/V65+zYH4pdK5RsC+fyxLsK+cy9CtkzeHcfGFd9xER+rnE2B4uHxpXvawjC1DGZeeweZiXxQJ2x8XQ9gebz9OBc5w20Zdd4Gzs5WXk07I42WRzuD7dOk3zDSt3cKbufb3CqJ5ZFluMzC3hxdeGKyx4VtgJm3tYlNEpm3s8PQdns1wbnz0grrKic7aAF8/TtDL3uDhbp4I7w1WNUNyc4eJMkBZvqquMFK1gzFcu5N1gQXAxJ2duQehszZ4RLxbJV7Q8e1NeW9Dv9/8c7PzwGwnmmT3nOErZAAAB1XpUWHRTTUlMRVMgcmRraXQgMjAyMy4wOS41AAB4nCWSq47cUBBEfyVSyFjyXPX7EZOVTIKGBUWLzDcgIGQ/PtVew+NWdVX1PX+fbz/f+Xw9zu08X3zxhe/xvOTjz/XAz7d3vX+dl116Pc7vr+16vLa/tn3I9sHfPh8SS41955XBtdtKVjlASb12WkbJoNRuQ6tzKFvULqus+ZBa0tX7EzjwV5eE1SG9uKsGSxpjmopsppUh+eRlbDLS5RDJ5coyWKh596WZORshIiMS6aBUMOeLWXpm2aVAM90HSyiwLNbKPVYC2mKMgHnDRC5teIDzNh9KSQ1KPkGA1W5dahUIUAaCMKxRjAcXWPQVZTpYNWLKqFbkCHI5uFcjFXrLnDbDRQc60V0FU9kYDtjgQsk1dRKqRlKVOjgh7/e21BzHRuSDETJxJo+cbIoLHByoHpF5NdcYVuE+GPqzhrE9Gibg6J5lu0+qJAFqiD66nHZbM6Gc4cKlgQUVTRUxTdnS4BzHUhxTHC490hHikw8JUJwu65wuKureqKr3TRvZ8DA0Q28j4TzTSCZ4GEGq41r6y4mb5jwjhojAb0t/9cGNjGaF9nX1+J2HofdRTMO3/d+vH7jePrHq8z9SP6Pv6mfr5AAAAABJRU5ErkJggg==",
       "text/plain": [
-       "<rdkit.Chem.rdchem.Mol at 0x7b30abe514d0>"
+       "11"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Open .sdf file using to see kras reference ligand.\n",
-    "# Reference ligand extracated from pdb file to ensure pocket\n",
-    "# coodinates.\n",
-    "from rdkit.Chem import MolFromMolFile\n",
-    "MolFromMolFile(\"/workspace/examples/kras_ref_ligand.sdf\")"
+    "from rdkit import Chem\n",
+    "from rdkit.Chem import SDWriter\n",
+    "\n",
+    "def filter_single_molecule_states(input_sdf: str, output_sdf: str) -> int:\n",
+    "    \"\"\"\n",
+    "    Filters and writes only single-molecule states from an SDF file.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    input_sdf : str\n",
+    "        Path to the input SDF file containing multiple states.\n",
+    "    output_sdf : str\n",
+    "        Path to save the filtered SDF file containing only single-molecule entries.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    int\n",
+    "        Number of single-molecule entries written to the output file.\n",
+    "    \"\"\"\n",
+    "    suppl = Chem.SDMolSupplier(input_sdf, removeHs=False)\n",
+    "    writer = SDWriter(output_sdf)\n",
+    "    count = 0\n",
+    "\n",
+    "    for mol in suppl:\n",
+    "        if mol is None:\n",
+    "            continue  # Skip unreadable entries\n",
+    "        # Check number of fragments\n",
+    "        frags = Chem.GetMolFrags(mol, asMols=True)\n",
+    "        if len(frags) == 1:\n",
+    "            writer.write(mol)\n",
+    "            count += 1\n",
+    "\n",
+    "    writer.close()\n",
+    "    return count\n",
+    "\n",
+    "filter_single_molecule_states(\n",
+    "    input_sdf=\"/workspace/datasets/boltz2/predict2/boltz_results_boltz2-example/samples.sdf\",\n",
+    "    output_sdf=\"/workspace/datasets/boltz2/predict2/boltz_results_boltz2-example/samples_filtered.sdf\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d438c11c",
+   "id": "d2d9a804",
    "metadata": {},
    "source": [
-    "Below is the example of the output generated from DrugFlow generation.\n",
+    "After filtering oput multi-fragment molecules, we end up with only 11 as shown in animation below\n",
     "\n",
-    "![DrugFlow Example Output](../assets/images/drugflow/state-sweep-example.gif)\n"
+    "![11-fragment-animation](https://storage.googleapis.com/gn-portfolio/images/drugflow_bcl2_generated_structures.gif)\n",
+    "\n",
+    "Lets move on to ranking these 11 samples using Boltz2"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f86e621",
+   "id": "3e4e8de0",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -316,7 +431,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "drugflow",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -330,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### ✅ Pull Request: Add DrugFlow example notebook and filtering logic

**Closes**: #33-generate-chemical-structures-using-drugflow
**Author**: @gabenavarro
**Date**: June 11, 2025

---

### Summary

This PR adds a worked example for using `DrugFlow` to generate chemical structures from a protein-ligand complex and includes a filtering utility to remove multi-fragment molecules from the results. This is part of the integration of DrugFlow for generative structure-based drug design and enables cleaner inputs for downstream scoring/ranking (e.g., with Boltz2).

---

### 📁 Files Changed

* `documentation/drugflow.ipynb`:

  * **+201 lines**, **−86 lines**
  * Added example of using DrugFlow CLI to generate molecules.
  * Included `.sdf` filtering logic using RDKit to retain only single-fragment molecules.
  * Added visual output and animations showing generated and filtered structures.
  * New markdown and code cells explaining filtering and preparing results for Boltz2.

---

### 🚀 Highlights

* Parsed and displayed DrugFlow CLI usage and example run with KRAS protein and reference ligand.
* Added RDKit utility: `filter_single_molecule_states(...)`.
* Filtered multi-fragment SDF entries to yield a clean set of 11 drug-like molecules.
* Embedded sample output animation for visual validation of generation and filtering.
* Updated `nbformat` and kernel metadata.

---

### 🧪 Next Steps

* Rank the filtered molecules using Boltz2 scoring engine (in progress).
* Evaluate generated molecules against known binders and compare to FDA-approved libraries.